### PR TITLE
Get times from last week

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ def get_arrival_stations(station):
 
 
 def main():
-    app.run(debug=True)
+    app.run()
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -88,19 +88,6 @@ def get_departures(departure_station, arrival_station, date):
     return jsonify(sorted(r.json()["data"]))
 
 
-def get_train_number(departure_station, arrival_station, departure_time):
-    r = requests.get(
-        "https://evf-regionsormland.preciocloudapp.net/api/TrainStations/GetDistance",
-        params={
-            "departureStationId": departure_station,
-            "arrivalStationId": arrival_station,
-            "departureDate": departure_time,
-        },
-    )
-
-    return r.json()["data"]["trafikverketTrainId"]
-
-
 @app.route("/api/arrival_stations/<station>", methods=["GET"])
 def get_arrival_stations(station):
     arrival_stations = {

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import (
     send_from_directory,
     jsonify,
 )
+from dateutil import parser
 import datetime
 import requests
 import operators
@@ -78,7 +79,9 @@ def get_departures(departure_station, arrival_station, date):
         params={
             "departureStationId": departure_station,
             "arrivalStationId": arrival_station,
-            "departureDate": date,
+            "departureDate": (parser.parse(date) - datetime.timedelta(days=7)).strftime(
+                "%Y-%m-%d"
+            ),
         },
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.3
 Requests==2.32.3
 gunicorn==23.0.0
+python-dateutil==2.8.2


### PR DESCRIPTION
There's a ~1 hour delay before departures start showing up in the Mälartåg API, sometimes more. Should maybe eventually switch to another API with better functionality and less quirks, but for now, grabbing times from same day last week - since in pretty much all cases traffic will be the same on a daily basis between weeks. This makes it possible to submit requests without having to wait for the departure to show up in today's results.